### PR TITLE
Removed setSortOption in ProductSearchQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,15 @@ sdfsdfsd
 sdfsdfsf
 sfsdf
 
-sdfsfsdsdfsdfsdfsdfsdfdsfsdfsdf
+sdfsfsdsdfsdfsdfsdfsdfdsfsdfsdfsdfdsfdsfdsf
+sd
+fsd
+f
+dsf
+sd
+f
+dsf
+sdf
 fsddsf
 sdf
 dsf


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | I believe it's some kind of leftover from developing this search feature. There's a few problems with it. 1. SortOption class is not even defined in PrestaShop. 2. setSortOption is never used. 3. There's setSortOrder method which sets all sorting options.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | See code changes.